### PR TITLE
Set Content-Security-Policy

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+Header set Content-Security-Policy "default-src 'self' data: 'unsafe-inline' https://www.apachecon.com/ https://analytics.apache.org/; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://analytics.apache.org/; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; img-src 'self' 'https://www.apache.org/';" 


### PR DESCRIPTION
Set `Content-Security-Policy` in line with INFRA-26115 and https://privacy.apache.org/policies/website-policy.html

Currently Swagger makes external calls, violating the policy. I'm not sure if this will break Swagger, but at least it will prevent it from making external calls.